### PR TITLE
[BPROC-253] :recycle: change function

### DIFF
--- a/seq.go
+++ b/seq.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
+	str "strings"
 	"sync"
 	"time"
 
@@ -109,12 +110,13 @@ func (sw *Writer) send(events []interface{}) error {
 	}
 	defer response.Body.Close()
 	if response.StatusCode != 201 {
-		bodyBytes, err := ioutil.ReadAll(response.Body)
+		buffer := new(str.Builder)
+		_, err := io.Copy(buffer, response.Body)
 		if err != nil {
 			stderr("ERROR PARSER SEQ RESPONSE %s", err)
 		}
 
-		stderr("COULD NOT SEND LOG TO SEQ BECAUSE %v; request: %s; response: %s", response.Status, string(body), string(bodyBytes))
+		stderr("COULD NOT SEND LOG TO SEQ BECAUSE %v; request: %s; response: %s", response.Status, string(body), buffer.String())
 		return errors.New(fmt.Sprintf("request returned %v", response.StatusCode))
 	}
 	return nil

--- a/seq.go
+++ b/seq.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/json-iterator/go"
-	"github.com/mralves/tracer"
-	"github.com/mundipagg/tracer-seq-writer/buffer"
-	"github.com/mundipagg/tracer-seq-writer/json"
-	"github.com/mundipagg/tracer-seq-writer/strings"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
 	"sync"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/mralves/tracer"
+	"github.com/mundipagg/tracer-seq-writer/buffer"
+	"github.com/mundipagg/tracer-seq-writer/json"
+	"github.com/mundipagg/tracer-seq-writer/strings"
 )
 
 type Writer struct {
@@ -108,7 +109,7 @@ func (sw *Writer) send(events []interface{}) error {
 	}
 	defer response.Body.Close()
 	if response.StatusCode != 201 {
-		bodyBytes, err := io.ReadAll(response.Body)
+		bodyBytes, err := ioutil.ReadAll(response.Body)
 		if err != nil {
 			stderr("ERROR PARSER SEQ RESPONSE %s", err)
 		}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Cannot update package in projects using a version of Go earlier than v1.16
| **Why?**          | The io.ReadAll function is not available in versions of Go prior to 1.16 and therefore projects that use older versions of Go cannot be upgraded
| **How?**          | Change io.ReadAll by io.Copy

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
